### PR TITLE
Adapt to basic-card deprecation

### DIFF
--- a/payment-request/index.html
+++ b/payment-request/index.html
@@ -7,10 +7,7 @@
     <script>
       const requestPayment = async e => {
           const request = new PaymentRequest([{
-              supportedMethods: "basic-card",
-              data: {
-                  supportedNetworks: ["visa", "master", "amex"]
-              }
+              supportedMethods: "https://bobbucks.dev/pay",
           }], {
               total: {
                   label: "total",


### PR DESCRIPTION
As of Chrome M100, basic-card support has been removed. Instead, use the test
payment app BobBucks (https://bobbucks.dev/) for the payment.